### PR TITLE
Extract header back button into reusable component

### DIFF
--- a/app/(protected)/(screens)/settings/_layout.tsx
+++ b/app/(protected)/(screens)/settings/_layout.tsx
@@ -1,18 +1,14 @@
-import { Stack, useRouter } from 'expo-router';
-import { Button } from 'react-native';
+import { HeaderBackButton } from '@/components/ui/header-back-button';
+import { Stack } from 'expo-router';
 
 export default function SettingsLayout() {
-  const router = useRouter();
-
   return (
     <Stack>
       <Stack.Screen
         name='index'
         options={{
           title: 'Settings',
-          headerRight: () => (
-            <Button onPress={() => router.back()} title='Back' />
-          ),
+          headerLeft: () => <HeaderBackButton />,
         }}
       />
     </Stack>

--- a/app/(protected)/bristol/_layout.tsx
+++ b/app/(protected)/bristol/_layout.tsx
@@ -1,22 +1,14 @@
-import { Stack, useRouter } from 'expo-router';
-import { TouchableOpacity } from 'react-native';
+import { HeaderBackButton } from '@/components/ui/header-back-button';
+import { Stack } from 'expo-router';
 
-import { Text } from 'tamagui';
-
-export default function ChatLayout() {
-  const router = useRouter();
-
+export default function BristolLayout() {
   return (
     <Stack>
       <Stack.Screen
         name='index'
         options={{
           title: 'Bristol Scale',
-          headerRight: () => (
-            <TouchableOpacity onPress={() => router.back()}>
-              <Text>Done</Text>
-            </TouchableOpacity>
-          ),
+          headerLeft: () => <HeaderBackButton />,
         }}
       />
     </Stack>

--- a/components/ui/header-back-button.tsx
+++ b/components/ui/header-back-button.tsx
@@ -1,0 +1,22 @@
+import { Colors } from '@/constants/theme';
+import { X } from '@tamagui/lucide-icons';
+import { useRouter } from 'expo-router';
+import { Pressable, useColorScheme } from 'react-native';
+
+export function HeaderBackButton() {
+  const router = useRouter();
+  const scheme = useColorScheme() ?? 'light';
+
+  return (
+    <Pressable
+      onPress={() => router.back()}
+      hitSlop={8}
+      style={({ pressed }) => ({
+        opacity: pressed ? 0.6 : 1,
+        padding: 4,
+      })}
+    >
+      <X size={22} color={Colors[scheme].icon as string} />
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary
Refactored duplicate back button implementations across layout files into a single, reusable `HeaderBackButton` component to improve code maintainability and consistency.

## Key Changes
- Created new `HeaderBackButton` component in `components/ui/header-back-button.tsx` that encapsulates back navigation logic
- Replaced custom back button implementations in Bristol Scale and Settings layouts with the new component
- Moved back button from `headerRight` to `headerLeft` position for better UX consistency
- Updated button styling to use an X icon with theme-aware colors and proper touch feedback

## Implementation Details
- The new component uses `expo-router`'s `useRouter` hook for navigation
- Implements theme-aware icon coloring via the `Colors` constant
- Includes proper touch feedback with opacity change on press and adequate hit slop for accessibility
- Removed unused router imports from layout files after consolidation

https://claude.ai/code/session_01TLyN1YR2Y8qnTRBrgEtBym