### PR TITLE
Add toilet rating display to poop details view

### DIFF
--- a/components/bottom-sheet/poop-details-view.tsx
+++ b/components/bottom-sheet/poop-details-view.tsx
@@ -63,7 +63,7 @@ export function PoopDetailsView({
   });
 
   const { data: toiletRating } = useToiletRatingForPlace(
-    poopDetails?.place_id ?? ''
+    poopDetails?.place_id ?? '',
   );
 
   const updateSeshMutation = useUpdatePoopSesh();
@@ -80,7 +80,7 @@ export function PoopDetailsView({
         },
       });
     },
-    [poopDetails, updateSeshMutation]
+    [poopDetails, updateSeshMutation],
   );
 
   useEffect(() => {
@@ -160,7 +160,7 @@ export function PoopDetailsView({
           >
             {format(
               new Date(poopDetails?.started ?? new Date()),
-              'dd/MM/yyyy h:mm a'
+              'dd/MM/yyyy h:mm a',
             )}
           </Button>
           <DatePicker
@@ -173,7 +173,7 @@ export function PoopDetailsView({
                 new Date(poopDetails?.ended ?? new Date()).getTime()
               ) {
                 Alert.alert(
-                  'You cannot set the start date to a time after the end date'
+                  'You cannot set the start date to a time after the end date',
                 );
                 setStartDatePickerOpen(false);
               } else {
@@ -184,7 +184,7 @@ export function PoopDetailsView({
             onCancel={() => setStartDatePickerOpen(false)}
           />
         </YStack>
-        <YStack>
+        <YStack mb='$3'>
           <Label htmlFor='poop-end-button'>Poop End</Label>
           <Button
             id='poop-end-button'
@@ -192,7 +192,7 @@ export function PoopDetailsView({
           >
             {format(
               new Date(poopDetails?.ended ?? new Date()),
-              'dd/MM/yyyy h:mm a'
+              'dd/MM/yyyy h:mm a',
             )}
           </Button>
           <DatePicker
@@ -205,7 +205,7 @@ export function PoopDetailsView({
                 new Date(poopDetails?.started ?? new Date()).getTime()
               ) {
                 Alert.alert(
-                  'You cannot set the end date to a time before the start date'
+                  'You cannot set the end date to a time before the start date',
                 );
                 setEndDatePickerOpen(false);
               } else {
@@ -255,10 +255,7 @@ export function PoopDetailsView({
                   <Text fontSize='$3'>{toiletRating.rating.toFixed(1)}</Text>
                 </XStack>
               ) : (
-                <Text
-                  fontSize='$3'
-                  color={Colors[scheme].textSecondary as any}
-                >
+                <Text fontSize='$3' color={Colors[scheme].textSecondary as any}>
                   Not rated yet
                 </Text>
               )}

--- a/components/bottom-sheet/poop-details-view.tsx
+++ b/components/bottom-sheet/poop-details-view.tsx
@@ -2,29 +2,33 @@ import { LogSwitch } from '@/components/ui/log-switch';
 import { RoundButton } from '@/components/ui/round-button';
 import { BRISTOL_SCORE_OPTIONS } from '@/constants';
 import { SheetContentProps, SheetType } from '@/constants/sheet';
+import { Colors } from '@/constants/theme';
 import {
   useDeletePoop,
   useUpdatePoopSesh,
 } from '@/hooks/api/usePoopSeshMutations';
 import { usePoopSesh } from '@/hooks/api/usePoopSeshQueries';
+import { useToiletRatingForPlace } from '@/hooks/api/useToiletRatingsQueries';
 import {
   validateAirportCode,
   validateFlightNumber,
 } from '@/lib/flight-helpers';
 import { PoopSesh } from '@/lib/types';
-import { CircleHelp, Plane, X } from '@tamagui/lucide-icons';
+import { CircleHelp, MapPin, Plane, X } from '@tamagui/lucide-icons';
 import { toast } from 'burnt';
 import { format } from 'date-fns';
 import { useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, TouchableOpacity } from 'react-native';
+import { Alert, TouchableOpacity, useColorScheme } from 'react-native';
 import DatePicker from 'react-native-date-picker';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import {
   AlertDialog,
   Button,
   Image,
   Input,
   Label,
+  Separator,
   Spinner,
   Text,
   TextArea,
@@ -43,6 +47,7 @@ export function PoopDetailsView({
   setSheetType,
 }: SheetContentProps) {
   const router = useRouter();
+  const scheme = useColorScheme() ?? 'light';
 
   const [startDatePickerOpen, setStartDatePickerOpen] = useState(false);
   const [endDatePickerOpen, setEndDatePickerOpen] = useState(false);
@@ -56,6 +61,10 @@ export function PoopDetailsView({
   const { data: poopDetails, isLoading } = usePoopSesh(poopDetailsId ?? null, {
     enabled: !!poopDetailsId,
   });
+
+  const { data: toiletRating } = useToiletRatingForPlace(
+    poopDetails?.place_id ?? ''
+  );
 
   const updateSeshMutation = useUpdatePoopSesh();
   const deleteSeshMutation = useDeletePoop();
@@ -207,6 +216,55 @@ export function PoopDetailsView({
             onCancel={() => setStartDatePickerOpen(false)}
           />
         </YStack>
+        {(poopDetails?.place || poopDetails?.custom_place_name) && (
+          <YStack
+            gap='$3'
+            p='$3'
+            borderWidth={1}
+            style={{ borderRadius: 16 }}
+            borderColor='$borderColor'
+          >
+            <XStack items='center' gap='$2'>
+              <MapPin size={16} />
+              <Text fontWeight='bold'>Bathroom</Text>
+            </XStack>
+            <Text fontSize='$4'>
+              {poopDetails.place?.name || poopDetails.custom_place_name}
+            </Text>
+            <Separator />
+            <YStack gap='$1'>
+              <Text fontSize='$3' color={Colors[scheme].textSecondary as any}>
+                Your rating
+              </Text>
+              {toiletRating?.rating ? (
+                <XStack items='center' gap='$2'>
+                  <XStack gap='$1'>
+                    {Array.from({ length: 5 }).map((_, index) => (
+                      <Icon
+                        key={index}
+                        name='star'
+                        size={16}
+                        color={
+                          index < Math.round(toiletRating.rating)
+                            ? (Colors[scheme].primary as string)
+                            : (Colors[scheme].border as string)
+                        }
+                      />
+                    ))}
+                  </XStack>
+                  <Text fontSize='$3'>{toiletRating.rating.toFixed(1)}</Text>
+                </XStack>
+              ) : (
+                <Text
+                  fontSize='$3'
+                  color={Colors[scheme].textSecondary as any}
+                >
+                  Not rated yet
+                </Text>
+              )}
+            </YStack>
+          </YStack>
+        )}
         <YStack>
           <Label htmlFor='revelations-textarea'>Revelations</Label>
           <TextArea

--- a/hooks/api/usePoopSeshQueries.tsx
+++ b/hooks/api/usePoopSeshQueries.tsx
@@ -163,7 +163,7 @@ export function usePoopSesh(
     queryKey: ['poop-sesh', { poopId }],
     queryFn: async (): Promise<PoopSesh | null> => {
       if (!poopId) return null;
-      const expand = `user`;
+      const expand = `user,place_id`;
       try {
         const sesh = await pb?.collection('poop_seshes').getOne(poopId, {
           expand,
@@ -184,6 +184,15 @@ export function usePoopSesh(
           user: sesh?.user,
           is_public: sesh?.is_public ?? false,
           company_time: sesh?.company_time ?? false,
+          place_id: sesh?.place_id,
+          place: sesh?.expand?.place_id,
+          custom_place_name: sesh?.custom_place_name,
+          place_type: sesh?.place_type,
+          is_airplane: sesh?.is_airplane,
+          flight_number: sesh?.flight_number,
+          airline: sesh?.airline,
+          departure_airport: sesh?.departure_airport,
+          arrival_airport: sesh?.arrival_airport,
         } as PoopSesh;
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Summary
This PR adds the ability to display toilet ratings and bathroom information in the poop details bottom sheet. Users can now see which bathroom a poop session was logged at and view their rating for that specific toilet location.

## Key Changes
- **Bathroom Information Display**: Added a new section in the poop details view that shows the bathroom name (from place data or custom place name) with a location icon
- **Toilet Rating Integration**: Integrated the `useToiletRatingForPlace` hook to fetch and display user ratings for the specific bathroom location
- **Star Rating Visualization**: Implemented a 5-star rating display using FontAwesome icons, with filled stars based on the rating value
- **Enhanced Data Fetching**: Updated `usePoopSesh` query to expand and return place-related data including `place_id`, `custom_place_name`, `place_type`, and flight information
- **UI Improvements**: Added proper styling with borders, separators, and color scheme support for the new bathroom section
- **Conditional Rendering**: The bathroom section only displays when place or custom place name data is available

## Implementation Details
- Uses the existing `Colors` theme constants for consistent styling across light/dark modes
- Displays "Not rated yet" message when no rating exists for the bathroom
- Rounds star ratings to nearest integer for display while showing decimal value (e.g., 4.5)
- Properly handles both place data from the database and custom place names entered by users

https://claude.ai/code/session_01HeKQYMJGnsUuh6dzpFmLrX