### PR TITLE
Remove Alert dialog from location permission denial flow

### DIFF
--- a/context/locationContext.tsx
+++ b/context/locationContext.tsx
@@ -1,6 +1,5 @@
 import * as Location from 'expo-location';
 import { createContext, useContext, useEffect, useState } from 'react';
-import { Alert } from 'react-native';
 
 export const LocationContext = createContext<{
   userLocation: { lat: number; lon: number };
@@ -36,11 +35,8 @@ export function LocationContextProvider({
       setIsLoadingLocation(true);
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
+        setHasLocation(false);
         setIsLoadingLocation(false);
-        Alert.alert(
-          'Permission not granted',
-          'Please grant permission to access your location'
-        );
         return;
       }
 


### PR DESCRIPTION
## Summary
Removed the native Alert dialog that was displayed when location permission was denied, and replaced it with a state update to track the permission denial.

## Key Changes
- Removed `Alert` import from `react-native`
- Replaced `Alert.alert()` call with `setHasLocation(false)` when location permission is not granted
- Simplified the permission denial handling to rely on state management instead of user-facing alerts

## Implementation Details
When the user denies location permission, the component now sets `hasLocation` to `false` and stops the loading state, allowing the UI to handle the denied permission state through the context state rather than through a modal alert. This provides a cleaner separation of concerns where state management drives the UI behavior instead of imperative alerts.

https://claude.ai/code/session_011cSUjVsnkRusuLTpXRJUb7