### PR TITLE
Fix notification routing for 10-minute poop sesh alert

### DIFF
--- a/context/notificationContext.tsx
+++ b/context/notificationContext.tsx
@@ -260,23 +260,38 @@ export const NotificationProvider = ({
         updateBadgeCount();
       });
 
+    return () => {
+      subscription.remove();
+      notificationListener.current?.remove();
+    };
+  }, [pooProfile]);
+
+  // Separate effect so the response listener is registered immediately,
+  // before pooProfile is available, to avoid missing cold-start taps.
+  useEffect(() => {
+    // Handle cold-start: app was killed and opened by tapping the notification.
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (!response) return;
+      const data = response.notification.request.content.data ?? {};
+      resetBadgeCount();
+      if (data.screen) {
+        router.push(data.screen as any);
+      }
+    });
+
     responseListener.current =
       Notifications.addNotificationResponseReceivedListener((response) => {
         const data = response.notification.request.content.data ?? {};
-
         resetBadgeCount();
-
         if (data.screen) {
           router.push(data.screen as any);
         }
       });
 
     return () => {
-      subscription.remove();
-      notificationListener.current?.remove();
       responseListener.current?.remove();
     };
-  }, [pooProfile]);
+  }, [router]);
 
   const handleScheduleNotification = async ({
     identifier,

--- a/context/seshContext.tsx
+++ b/context/seshContext.tsx
@@ -145,7 +145,7 @@ export const SeshContextProvider = ({
                             identifier: 'poop-sesh-started',
                             sendAt,
                             title: 'Are you ok?',
-                            data: { screen: 'poop-sesh-started' },
+                            data: { screen: '/(protected)' },
                             body: "You've been sitting there for a while. Are you ok?",
                           });
                         } catch (notificationError) {
@@ -211,6 +211,7 @@ export const SeshContextProvider = ({
                         identifier: 'poop-sesh-started',
                         sendAt,
                         title: 'Are you ok?',
+                        data: { screen: '/(protected)' },
                         body: "You've been sitting there for a while. Are you ok?",
                       });
                     } catch (notificationError) {
@@ -289,7 +290,7 @@ export const SeshContextProvider = ({
           sendAt,
           title: 'Are you ok?',
           data: {
-            screen: 'poop-sesh-started',
+            screen: '/(protected)',
           },
           body: "You've been sitting there for a while. Are you ok?",
         });


### PR DESCRIPTION
Three bugs were preventing correct navigation when tapping the notification:

1. Invalid screen path: data.screen was 'poop-sesh-started' but no such
   route exists in Expo Router. Changed to '/(protected)', which renders
   the map with the active-sesh sheet overlay.

2. Missing data field in the airplane-mode notification schedule call,
   so tapping it never triggered any navigation.

3. Cold-start race: the response listener was inside a useEffect guarded
   by pooProfile availability. If the app was killed and opened by tapping
   the notification, the listener registered too late to catch the response.
   Moved the response listener to its own useEffect (runs immediately) and
   added getLastNotificationResponseAsync() to handle the killed-app case.

https://claude.ai/code/session_01SdvpqFWvWewzZDmRevY9R2