### PR TITLE
Fix cold start notification handling and update screen routes

### DIFF
--- a/context/notificationContext.tsx
+++ b/context/notificationContext.tsx
@@ -185,6 +185,7 @@ export const NotificationProvider = ({
 
   const notificationListener = useRef<Notifications.EventSubscription>(null);
   const responseListener = useRef<Notifications.EventSubscription>(null);
+  const hasHandledColdStart = useRef(false);
 
   // Add this function to check permissions and register if granted
   const checkAndRegisterForNotifications = async () => {
@@ -270,6 +271,20 @@ export const NotificationProvider = ({
           router.push(data.screen as any);
         }
       });
+
+    // Handle the case where the app was launched (cold start) by tapping a
+    // notification, which the response listener above would otherwise miss.
+    if (!hasHandledColdStart.current) {
+      hasHandledColdStart.current = true;
+      Notifications.getLastNotificationResponseAsync().then((response) => {
+        if (!response) return;
+        const data = response.notification.request.content.data ?? {};
+        resetBadgeCount();
+        if (data.screen) {
+          router.push(data.screen as any);
+        }
+      });
+    }
 
     return () => {
       subscription.remove();

--- a/context/seshContext.tsx
+++ b/context/seshContext.tsx
@@ -145,7 +145,7 @@ export const SeshContextProvider = ({
                             identifier: 'poop-sesh-started',
                             sendAt,
                             title: 'Are you ok?',
-                            data: { screen: 'poop-sesh-started' },
+                            data: { screen: '/(protected)' },
                             body: "You've been sitting there for a while. Are you ok?",
                           });
                         } catch (notificationError) {
@@ -211,6 +211,7 @@ export const SeshContextProvider = ({
                         identifier: 'poop-sesh-started',
                         sendAt,
                         title: 'Are you ok?',
+                        data: { screen: '/(protected)' },
                         body: "You've been sitting there for a while. Are you ok?",
                       });
                     } catch (notificationError) {
@@ -289,7 +290,7 @@ export const SeshContextProvider = ({
           sendAt,
           title: 'Are you ok?',
           data: {
-            screen: 'poop-sesh-started',
+            screen: '/(protected)',
           },
           body: "You've been sitting there for a while. Are you ok?",
         });


### PR DESCRIPTION
## Summary
This PR fixes notification handling when the app is launched via a notification tap (cold start) and updates notification screen routing to use the correct protected route path.

## Key Changes

- **Cold start notification handling**: Added logic to `NotificationProvider` to check for pending notifications when the app first loads using `Notifications.getLastNotificationResponseAsync()`. This ensures notifications that launched the app are properly processed, even before the response listener is fully set up.

- **Updated notification screen routes**: Changed all notification `data.screen` values from `'poop-sesh-started'` to `'/(protected)'` in `SeshContextProvider`. This aligns with the app's Expo Router file-based routing structure where protected routes use the `(protected)` route group.

- **Added missing data field**: Added the missing `data: { screen: '/(protected)' }` field to one notification configuration that was previously omitted.

## Implementation Details

The cold start fix uses a `useRef` flag (`hasHandledColdStart`) to ensure the notification check only runs once during the component's lifecycle. This prevents duplicate processing and race conditions with the response listener that handles notifications received while the app is already running.

The route updates ensure consistent navigation behavior - tapping a notification now correctly routes to the protected routes section of the app rather than attempting to navigate to a non-existent screen name.

https://claude.ai/code/session_01BnMH6Y1MXxFYymZtfoY1X8